### PR TITLE
Add an option to build only the libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,13 @@ target_include_directories(libpnp PRIVATE ${CERES_INCLUDE_DIRS})
 target_link_libraries(libpnp ${CERES_LIBRARIES})
 target_compile_features(libpnp PUBLIC cxx_std_11)
 
-add_executable(main test_pnp.cpp)
-target_link_libraries(main libpnp)
+
+option(LIB_ONLY "Build only the library" OFF)
+
+if(NOT LIB_ONLY)
+    add_executable(main test_pnp.cpp)
+    target_link_libraries(main libpnp)
+endif()
 
 
 option(WITH_PYBIND11 "with pybind11 bindings" OFF)


### PR DESCRIPTION
Hi, I wanted to use the libpnp as a submodule in a larger project of mine, but there is this target main, which is created in all cases and is a bit dirty. I propose this small change to the CMakeLists.txt (which do not impact the default behaviour by the way) to just be able to turn off the target main, or any other executable that might be added in the future. This would make the base repository much easier to use as a git submodule.

Let me know if I need to do things a bit differently.

Best regards

Paragon